### PR TITLE
Make whitespace and comments consistent with internal versions

### DIFF
--- a/sharedLibEvents.h
+++ b/sharedLibEvents.h
@@ -14,7 +14,7 @@
    limitations under the License.
  */
 
-//! @file sharedLibEventsManifest.h
+//! @file sharedLibEvents.h
 //! This is the events interface that a shared library will implement to have
 //! code triggering events into the policy engine.
 
@@ -30,21 +30,24 @@ extern "C" {
 // handle for an instance of an event allocated and freed by shared lib.
 typedef void* psl_EventInstanceHandle;
 
-//! @param context      Provides the context number of the event that is returned.
+//! @param context      The context number of the event being polled (in case the same function is used for different contexts).
 //! @param eventHandle  Returns a handle to the memory holding an event.
 //! @return -1 if no events; otherwise the number of events waiting after this one.
 typedef int psl_PollEventsFn(unsigned context, psl_EventInstanceHandle* eventHandle);
 
 typedef void psl_FreeEventFn(psl_EventInstanceHandle eventHandle);
 
+//! Description of an event raised by the shared library.
 typedef struct psl_EventDescription
 {
-	const char*  eventName;     // what the event should be called in error logs, PDB, etc.
-	unsigned     contextNumber;  // start numbering at 1.
-	// the function to call to see what events need to be run
-	psl_PollEventsFn* pollEvents;
-	// function to call to free an event handle
-	psl_FreeEventFn*   freeEvent;
+    //! what the event should be called in error logs, PDB, etc., such as "MyEvent"
+    const char*  eventName;    
+    //! A number the library uses to uniquely identify the event type. Must be unique within a library.
+    unsigned     contextNumber;
+    //! the function to call to see what events need to be run
+    psl_PollEventsFn * pollEvents;
+    //! function to call to free an event handle obtained by pollEvents
+    psl_FreeEventFn*   freeEvent;
 } psl_EventDescription;
 
 //! @param ResultLocation  Place the result here, of type type indicated in psl_EventField
@@ -52,24 +55,37 @@ typedef struct psl_EventDescription
 //! @return false if null, true otherwise (and result is provided)
 typedef bool psl_FieldGetFn(psl_Value* ResultLocation, psl_EventInstanceHandle eventHandle);
 
+//! Description of a field of an event raised by the shared library
 typedef struct psl_EventField
 {
-	unsigned contextNumber; // what context the field applies to
-	const char* fieldName;  // full name of field, such as MyEvent.foo
-	psl_DataType  type;     // is it string, float, etc.?
-	uint32_t      flags;    // isConstant, canOptimize, etc. TBD.
-	psl_FieldGetFn*  getFunction;  // call to obtain the field from the event pointed by handle.
+    //! The event (per psl_EventDescription::contextNumber) that this field may be used with.
+    unsigned contextNumber;
+    //! The name of the field to be exposed to SandScript, such as MyEvent.foo
+    const char* fieldName;
+    //! Type of the field;  is it string, float, etc.?
+    psl_DataType  type;    
+    //! flags, TBD. For now, use 0.
+    uint32_t      flags;
+    //! Function that SandScript will call to obtain the field identified by the handle.
+    psl_FieldGetFn*  getFunction;
 } psl_EventField;
 
+//! Manifest detailing the contents of the shared library regarding events raised by it.
 typedef struct psl_EventManifest
 {
-	unsigned version;
-	unsigned numDescriptions;
-	unsigned numFields;
-	const psl_EventDescription* const* eventDescriptions;
-	const psl_EventField* const* eventFields;
+    //! Library API version identifier. Use 1.
+    unsigned version;
+    //! Number of entries of the eventDescriptions array
+    unsigned numDescriptions;
+    //! Number of entries of the eventFields array.
+    unsigned numFields;
+    //! Array of pointers to each of the events that can be raised by the library.
+    const psl_EventDescription* const* eventDescriptions;
+    //! Array of pointers to each of the fields exposed by the library.
+    const psl_EventField* const* eventFields;
 } psl_EventManifest;
 
+//! The type of the function that is called GetEventManifest
 typedef const psl_EventManifest* psl_GetEventManifest();
 
 //! The function name to be retrieved via dlsym() from the shared library.

--- a/sharedLibManifest.h
+++ b/sharedLibManifest.h
@@ -33,12 +33,12 @@ extern "C" {
 // Describes one function in the shared library.
 typedef struct psl_FunctionDescription
 {
-	const char*   functionName;   //!< null-terminated string for the name of the function in policy.
-	uint32_t      flags;          //!< Flags. See psl_Flag_* Set unused bits to to 0.
-	psl_Function* functionPointer;//!< Function to be called at each invocation.
-	psl_DataType  returnType;     //!< Data type of the function return value.
-	uint16_t      numArgs;        //!< Number of arguments the function requires.
-	const psl_DataType* argTypes; //!< Data types of each function argument.
+    const char*   functionName;   //!< null-terminated string for the name of the function in policy.
+    uint32_t      flags;          //!< Flags. See psl_Flag_* Set unused bits to to 0.
+    psl_Function* functionPointer;//!< Function to be called at each invocation.
+    psl_DataType  returnType;     //!< Data type of the function return value.
+    uint16_t      numArgs;        //!< Number of arguments the function requires.
+    const psl_DataType* argTypes; //!< Data types of each function argument.
 } psl_FunctionDescription;
 
 // include this flag in the flags field if the function depends solely on its inputs.
@@ -47,12 +47,12 @@ typedef struct psl_FunctionDescription
 
 typedef struct psl_Manifest
 {
-	//! Library API version identifier. Use 1.
-	unsigned                       version;
-	//! Number of entries in the functionDescriptions array.
-	unsigned                       numFunctionDescriptions;
-	//! Array, with one entry for each function in the shared library.
-	const psl_FunctionDescription* const* functionDescriptions;
+    //! Library API version identifier. Use 1.
+    unsigned                       version;
+    //! Number of entries in the functionDescriptions array.
+    unsigned                       numFunctionDescriptions;
+    //! Array, with one entry for each function in the shared library.
+    const psl_FunctionDescription* const* functionDescriptions;
 } psl_Manifest;
 
 //! Function signature required for the function named "GetManifest"

--- a/sharedLibTypes.h
+++ b/sharedLibTypes.h
@@ -32,29 +32,29 @@ extern "C" {
 //! The possible argument and return types
 typedef enum psl_DataType
 {
-	psl_boolean = 0,
-	psl_string = 1,
-	psl_integer = 2,
-	psl_float = 3,
-	psl_ipaddress = 4
+    psl_boolean = 0,
+    psl_string = 1,
+    psl_integer = 2,
+    psl_float = 3,
+    psl_ipaddress = 4
 } psl_DataType;
 
 //! String arguments and return values are references, not passed by value.
 //! Strings are pointer/length (not null-terminated).
 typedef struct psl_stringRef
 {
-	const char*    begin;
-	unsigned       length;
+    const char*    begin;
+    unsigned       length;
 } psl_stringRef;
 
 //! The argument and return values, per psl_DataType
 typedef union psl_Value
 {
-	bool          b;     //!< boolean
-	struct psl_stringRef s;     //!< string reference
-	int64_t       i;     //!< integer
-	double        f;     //!< float
-	uint8_t       a[16]; //!< address IPv6 or IPv4-mapped-IPv6
+    bool          b;     //!< boolean
+    struct psl_stringRef s;     //!< string reference
+    int64_t       i;     //!< integer
+    double        f;     //!< float
+    uint8_t       a[16]; //!< address IPv6 or IPv4-mapped-IPv6
 } psl_Value;
 
 //! The function signature required for loadable functions.


### PR DESCRIPTION
Only comment and whitespace changes.